### PR TITLE
Feature/fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,22 @@
 TAG :=`git describe --tags`
 
 VERSION = `git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null`
-LDFLAGS = -X main.buildVersion $(VERSION)
+LDFLAGS = -X main.buildVersion=$(VERSION)
 
 all: shuttle
 
 deps:
-	glock sync github.com/litl/shuttle
+	glock sync github.com/skyfii/shuttle
 
 shuttle:
 	echo "Building shuttle"
-	go install -x -ldflags "$(LDFLAGS)" github.com/litl/shuttle
+	go install -x -ldflags "$(LDFLAGS)" github.com/skyfii/shuttle
 
 fmt:
-	go fmt github.com/litl/shuttle/...
+	go fmt github.com/skyfii/shuttle/...
 
 test:
-	go test -v github.com/litl/shuttle
+	go test -v github.com/skyfii/shuttle
 
 dist-clean:
 	rm -rf dist
@@ -30,7 +30,7 @@ dist-init:
 
 dist-build: dist-init
 	echo "Compiling $$GOOS/$$GOARCH"
-	go build -a -ldflags "$(LDFLAGS)" -o dist/$$GOOS/$$GOARCH/shuttle github.com/litl/shuttle
+	go build -a -ldflags "$(LDFLAGS)" -o dist/$$GOOS/$$GOARCH/shuttle github.com/skyfii/shuttle
 
 dist-linux-amd64:
 	export GOOS="linux"; \
@@ -47,12 +47,7 @@ dist-darwin-amd64:
 	export GOARCH="amd64"; \
 	$(MAKE) dist-build
 
-dist-darwin-386:
-	export GOOS="darwin"; \
-	export GOARCH="386"; \
-	$(MAKE) dist-build
-
-dist: dist-clean dist-init dist-linux-amd64 dist-linux-386 dist-darwin-amd64 dist-darwin-386
+dist: dist-clean dist-init dist-linux-amd64 dist-linux-386 dist-darwin-amd64
 
 release-tarball:
 	echo "Building $$GOOS-$$GOARCH-$(TAG).tar.gz"
@@ -73,9 +68,4 @@ release-darwin-amd64:
 	export GOARCH="amd64"; \
 	$(MAKE) release-tarball
 
-release-darwin-386:
-	export GOOS="darwin"; \
-	export GOARCH="386"; \
-	$(MAKE) release-tarball
-
-release: deps dist release-linux-amd64 release-linux-386 release-darwin-amd64 release-darwin-386
+release: deps dist release-linux-amd64 release-linux-386 release-darwin-amd64

--- a/main.go
+++ b/main.go
@@ -3,8 +3,7 @@ package main
 import (
 	"flag"
 	"sync"
-
-	"github.com/litl/shuttle/log"
+	"github.com/skyfii/shuttle/log"
 )
 
 var (
@@ -31,11 +30,12 @@ var (
 
 	// version flags
 	version      bool
-	buildVersion string
 
 	// SSL Certificate directory
 	certDir string
 )
+
+var buildVersion = "undefined"
 
 func init() {
 	flag.StringVar(&httpAddr, "http", "", "http server address")


### PR DESCRIPTION
Allowing version to be displayed by the shuttle binary. Importing upstream changes to Makefile to remove support for darwin-386.
